### PR TITLE
Create Python Script for Grabbing Screen Color (droplet.py)

### DIFF
--- a/droplet.py
+++ b/droplet.py
@@ -1,14 +1,23 @@
 from Xlib import display, X
-import time
-import sys
+import signal, time, sys
 
 interval = float(sys.argv[1]) if len(sys.argv) > 1 else 0.3
 
 d = display.Display()
 root = d.screen().root
+running = True
 
 GET_IMAGE_FORMAT = X.ZPixmap  # 2 → ZPixmap format (raw pixel data)
 PLANE_MASK_ALL = 0xFFFFFFFF  # Read all color planes (RGB, alpha if present)
+
+
+def stop_gracefully(*_):
+    global running
+    running = False
+
+
+signal.signal(signal.SIGINT, stop_gracefully)
+signal.signal(signal.SIGTERM, stop_gracefully)
 
 
 def get_pixel_color():
@@ -19,6 +28,6 @@ def get_pixel_color():
     return f"#{r:02x}{g:02x}{b:02x}"
 
 
-while True:
+while running:
     print(get_pixel_color(), flush=True)
     time.sleep(interval)

--- a/droplet.py
+++ b/droplet.py
@@ -1,0 +1,24 @@
+from Xlib import display, X
+import time
+import sys
+
+interval = float(sys.argv[1]) if len(sys.argv) > 1 else 0.3
+
+d = display.Display()
+root = d.screen().root
+
+GET_IMAGE_FORMAT = X.ZPixmap  # 2 → ZPixmap format (raw pixel data)
+PLANE_MASK_ALL = 0xFFFFFFFF  # Read all color planes (RGB, alpha if present)
+
+
+def get_pixel_color():
+    data = root.query_pointer()._data
+    x, y = data["root_x"], data["root_y"]
+    pixel = root.get_image(x, y, 1, 1, GET_IMAGE_FORMAT, PLANE_MASK_ALL).data
+    r, g, b = pixel[2], pixel[1], pixel[0]
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+while True:
+    print(get_pixel_color(), flush=True)
+    time.sleep(interval)

--- a/droplet.py
+++ b/droplet.py
@@ -1,5 +1,13 @@
 from Xlib import display, X
 import signal, time, sys
+from typing import NamedTuple
+
+
+class RGB(NamedTuple):
+    r: int
+    g: int
+    b: int
+
 
 interval = float(sys.argv[1]) if len(sys.argv) > 1 else 0.3
 
@@ -20,14 +28,48 @@ signal.signal(signal.SIGINT, stop_gracefully)
 signal.signal(signal.SIGTERM, stop_gracefully)
 
 
-def get_pixel_color():
+def get_pixel_color() -> RGB:
     data = root.query_pointer()._data
     x, y = data["root_x"], data["root_y"]
-    pixel = root.get_image(x, y, 1, 1, GET_IMAGE_FORMAT, PLANE_MASK_ALL).data
+    try:
+        pixel = root.get_image(x, y, 1, 1, GET_IMAGE_FORMAT, PLANE_MASK_ALL).data
+    except:
+        return RGB(0, 0, 0)
     r, g, b = pixel[2], pixel[1], pixel[0]
-    return f"#{r:02x}{g:02x}{b:02x}"
+    return RGB(r, g, b)
 
 
-while running:
-    print(get_pixel_color(), flush=True)
-    time.sleep(interval)
+def calculate_luminance(rgb: RGB) -> float:
+    r_norm = rgb.r / 255.0
+    g_norm = rgb.g / 255.0
+    b_norm = rgb.b / 255.0
+    return 0.2126 * r_norm + 0.7152 * g_norm + 0.0722 * b_norm
+
+
+def get_contrast_color(rgb: RGB) -> RGB:
+    luminance = calculate_luminance(rgb)
+
+    if luminance > 0.5:
+        return RGB(0, 0, 0)
+    else:
+        return RGB(255, 255, 255)
+
+
+def get_hex_code(rgb: RGB) -> str:
+    return f"#{rgb.r:02x}{rgb.g:02x}{rgb.b:02x}"
+
+
+def main():
+    while running:
+        active_color = get_pixel_color()
+        contrast_color = get_contrast_color(active_color)
+
+        active_hex = get_hex_code(active_color)
+        contrast_hex = get_hex_code(contrast_color)
+
+        print(f"{active_hex} {contrast_hex}")
+        time.sleep(interval)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Create Python Script for Grabbing Screen Color (droplet.py)

Closes #1 

## Overview
This adds the core Python script (droplet.py) responsible for grabbing the color under the mouse cursor and printing both:
- The active screen color in hex format
- A high-contrast foreground color (black or white), also in hex, for accessibility

# Why
This is the foundation of the Droplet plugin — enabling real-time or one-shot color detection from within AwesomeWM, via stdout integration with Lua.

# Implementation Details
- Polls the cursor position using Xlib for maximum speed and precision (no full-screen screenshots)
- Uses `ZPixmap` + `plane_mask` to grab 1×1 pixel from the X server
- Accepts a configurable interval (default: `0.3s`) via `argv`
- Outputs a space-separated pair of hex codes:
  - → Example: `#3fa7d6 #ffffff`
- Handles graceful exits via `SIGINT` and `SIGTERM`
- Includes luminance-based contrast logic for accessibility
- Typed with `NamedTuple` for clarity and maintainability

# Usage

```bash
python3 droplet.py         # uses default interval of 0.3s
python3 droplet.py 0.05    # custom interval in seconds
```

Example output (per line):
```
#2e3440 #ffffff
#2e3440 #ffffff
#e5e9f0 #000000
```